### PR TITLE
Show branches on News page

### DIFF
--- a/Controllers/NewsController.cs
+++ b/Controllers/NewsController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -13,7 +14,7 @@ public class NewsController : Controller
         var psi = new ProcessStartInfo
         {
             FileName = "git",
-            Arguments = "log --pretty=format:%h:::%s",
+            Arguments = "log --pretty=format:%h:::%s:::%an:::%cI",
             RedirectStandardOutput = true,
             UseShellExecute = false,
             WorkingDirectory = Directory.GetCurrentDirectory()
@@ -27,8 +28,38 @@ public class NewsController : Controller
             .Split('\n', StringSplitOptions.RemoveEmptyEntries)
             .Select(line =>
             {
-                var parts = line.Split(":::", 2);
-                return new CommitInfo { Hash = parts[0], Message = parts.Length > 1 ? parts[1] : string.Empty };
+                var parts = line.Split(":::", 4);
+                var hash = parts[0];
+                var message = parts.Length > 1 ? parts[1] : string.Empty;
+                var author = parts.Length > 2 ? parts[2] : string.Empty;
+                DateTime.TryParse(parts.Length > 3 ? parts[3] : string.Empty, out var date);
+
+                var branchPsi = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = $"branch --contains {hash} --format=\"%(refname:short)\"",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = Directory.GetCurrentDirectory()
+                };
+
+                using var branchProcess = Process.Start(branchPsi);
+                var branchOutput = branchProcess!.StandardOutput.ReadToEnd();
+                branchProcess.WaitForExit();
+
+                var branches = branchOutput
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(b => b.Trim())
+                    .ToList();
+
+                return new CommitInfo
+                {
+                    Hash = hash,
+                    Message = message,
+                    Author = author,
+                    Date = date,
+                    Branches = branches
+                };
             })
             .ToList();
 

--- a/Models/CommitInfo.cs
+++ b/Models/CommitInfo.cs
@@ -1,7 +1,13 @@
+using System;
+using System.Collections.Generic;
+
 namespace LifeCare.Models;
 
 public class CommitInfo
 {
     public string Hash { get; set; } = string.Empty;
     public string Message { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public List<string> Branches { get; set; } = new();
 }

--- a/Views/News/Index.cshtml
+++ b/Views/News/Index.cshtml
@@ -11,6 +11,13 @@
             <li class="list-group-item d-flex justify-content-between align-items-start py-2 px-3">
                 <div>
                     <code>@commit.Hash</code> @commit.Message
+                    <small class="text-muted d-block">
+                        by @commit.Author on @commit.Date.ToString("yyyy-MM-dd")
+                        @if (commit.Branches.Count > 0)
+                        {
+                            <span>from @string.Join(", ", commit.Branches)</span>
+                        }
+                    </small>
                 </div>
                 <a href="https://github.com/kofifi/LifeCare/commit/@commit.Hash" class="text-decoration-none">→</a>
             </li>


### PR DESCRIPTION
## Summary
- Include branch list for each commit in news feed
- Extend commit model to store branch names, author, and date
- Render branch, author, and date information on News page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a1082a2c8328a99b5c0c5c209ac8