### PR TITLE
Centralize view styling

### DIFF
--- a/Views/Habits/Details.cshtml
+++ b/Views/Habits/Details.cshtml
@@ -7,7 +7,7 @@ var icon = Model.Icon;
 }
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/Chart.min.css"/>
-<link rel="stylesheet" href="~/css/habits.details.css" asp-append-version="true"/>
+
 
 <div class="container py-4" id="habit-root"
      data-habit-id="@Model.Id"
@@ -277,68 +277,4 @@ var icon = Model.Icon;
 </script>
 }
 
-@section Styles {
-<style>
-    /* Karty w Details – ciemne tło, jasny tekst */
-    #habit-root .card {
-        background: var(--clr-surface-a20);
-        border: var(--border-soft);
-        color: var(--bs-body-color);
-        box-shadow: var(--shadow-soft);
-    }
-    #habit-root .card .card-body { background: transparent; }
-
-    #habit-root .btn-light {
-        background-color: var(--clr-surface-a30) !important;
-        color: var(--clr-light-a0) !important;
-        border-color: rgba(255,255,255,.12) !important;
-    }
-    
-    /* „light” przycisk używany jako label (np. month/week label) */
-    #habit-root .btn-light {
-        --bs-btn-bg: var(--clr-surface-a30);
-        --bs-btn-color: var(--clr-light-a0);
-        --bs-btn-border-color: rgba(255,255,255,0.08);
-        --bs-btn-hover-bg: var(--clr-surface-a40);
-        --bs-btn-hover-border-color: rgba(255,255,255,0.12);
-    }
-
-    /* Tabela kalendarza – ciemne nagłówki i ciemne komórki */
-    #habit-root .table {
-        --bs-table-bg: transparent;
-        --bs-table-color: var(--clr-light-a0);
-        color: var(--clr-light-a0);
-    }
-    #habit-root .table thead,
-    #habit-root .table thead.table-light {
-        --bs-table-bg: var(--clr-surface-a30);
-        --bs-table-color: var(--clr-light-a0);
-        background-color: var(--clr-surface-a30);
-        color: var(--clr-light-a0);
-    }
-    #habit-root .table-bordered {
-        border-color: rgba(255,255,255,0.12);
-    }
-    #habit-root .table-bordered > :not(caption) > * {
-        border-color: rgba(255,255,255,0.12);
-    }
-    #habit-root .table-bordered > :not(caption) > * > * {
-        border-color: rgba(255,255,255,0.12);
-        background-color: var(--clr-surface-a20);
-    }
-
-    /* Opakowanie canvasa, żeby wykres nie „wisiał” na jasnym */
-    #habit-root .chart-wrap-sm {
-        background: var(--clr-surface-a20);
-        border: var(--border-soft);
-        border-radius: var(--radius-md);
-        padding: .75rem;
-    }
-
-    /* Odrobinę kontrastu dla badge-warning z czarnym tekstem */
-    #habit-root .badge.bg-warning.text-dark {
-        color: #111 !important;
-    }
-</style>
-}
 

--- a/Views/Habits/Edit.cshtml
+++ b/Views/Habits/Edit.cshtml
@@ -109,20 +109,3 @@ var categories = ViewBag.Categories as List<Category>;
 </script>
 }
 
-@section Styles {
-<style>
-    /* Dark theme dla pól readonly/disabled w tym widoku */
-    .form-control[readonly],
-    .form-control:disabled,
-    .form-select:disabled {
-        background-color: var(--field-bg) !important; /* np. var(--clr-surface-a20) */
-        color: var(--bs-body-color) !important; /* jasny tekst */
-        border: var(--field-border) !important; /* spójna ramka */
-        opacity: 1; /* bez przygaszenia */
-    }
-
-    input[type=number]::-webkit-inner-spin-button {
-        -webkit-appearance: none;
-    }
-</style>
-}

--- a/Views/Shared/_IconPicker.cshtml
+++ b/Views/Shared/_IconPicker.cshtml
@@ -76,63 +76,7 @@ var icons = new[]
     </small>
 </div>
 
-<!-- STYLE (dark theme dla pickera) -->
-<style>
-    [data-iconpicker-root] { color: var(--bs-body-color, #fff); }
-
-    [data-iconpicker-root] .icon-preview {
-        color: var(--clr-light-a0, #fff);
-        font-size: 1.05rem;
-    }
-
-    [data-iconpicker-root] .icon-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
-        gap: .5rem;
-        max-height: 260px;
-        overflow: auto;
-
-        /* DARK tło + obramowanie z Twoich tokenów */
-        background: var(--clr-surface-a20, #2a2a2a);
-        border: 1px solid rgba(255,255,255,0.08) !important;
-    }
-
-    [data-iconpicker-root] .icon-option {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        height: 56px; width: 56px;
-        border: 1px solid rgba(255,255,255,.08);
-        border-radius: .5rem;
-        background: var(--clr-surface-a10, #1a1a1a);
-        cursor: pointer;
-        transition: transform .05s ease-in-out, box-shadow .1s ease-in-out, background .1s ease-in-out, border-color .1s ease-in-out;
-    }
-
-    [data-iconpicker-root] .icon-option:hover {
-        background: var(--clr-surface-a30, #3d3d3d);
-        border-color: rgba(255,255,255,.14);
-    }
-
-    [data-iconpicker-root] .icon-option:focus-visible {
-        outline: 2px solid var(--clr-primary-a40, #3399ff);
-        outline-offset: 1px;
-    }
-
-    [data-iconpicker-root] .icon-option.active {
-        outline: 2px solid var(--clr-primary-a40, #3399ff);
-        box-shadow: 0 0 0 2px rgba(51,153,255,.18) inset;
-        background: var(--clr-surface-tonal-a10, #243344);
-        border-color: rgba(51,153,255,.35);
-    }
-
-    [data-iconpicker-root] .icon-option i {
-        font-size: 22px;
-        color: var(--clr-light-a0, #fff); /* BIAŁE IKONY */
-    }
-</style>
-
-<!-- SCRIPT (samoinicjalizujący się) -->
+    <!-- SCRIPT (samoinicjalizujący się) -->
 <script>
     (function(){
         const root    = document.getElementById('@containerId');

--- a/wwwroot/css/habits.details.css
+++ b/wwwroot/css/habits.details.css
@@ -1,4 +1,0 @@
-﻿.chart-wrap-sm { height: 240px; }
-@media (min-width: 992px) {
-    .chart-wrap-sm { height: 200px; }
-}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -186,3 +186,129 @@ input[type="color"].form-control-color::-moz-color-swatch {
   background-clip: padding-box;
 }
 
+/* ===== Habit details page styles ======================================== */
+/* Ensure small chart wrapper has consistent height */
+.chart-wrap-sm { height: 240px; }
+@media (min-width: 992px) {
+  .chart-wrap-sm { height: 200px; }
+}
+
+#habit-root .card {
+  background: var(--clr-surface-a20);
+  border: var(--border-soft);
+  color: var(--bs-body-color);
+  box-shadow: var(--shadow-soft);
+}
+#habit-root .card .card-body { background: transparent; }
+
+#habit-root .btn-light {
+  background-color: var(--clr-surface-a30) !important;
+  color: var(--clr-light-a0) !important;
+  border-color: rgba(255,255,255,.12) !important;
+  --bs-btn-bg: var(--clr-surface-a30);
+  --bs-btn-color: var(--clr-light-a0);
+  --bs-btn-border-color: rgba(255,255,255,0.08);
+  --bs-btn-hover-bg: var(--clr-surface-a40);
+  --bs-btn-hover-border-color: rgba(255,255,255,0.12);
+}
+
+#habit-root .table {
+  --bs-table-bg: transparent;
+  --bs-table-color: var(--clr-light-a0);
+  color: var(--clr-light-a0);
+}
+#habit-root .table thead,
+#habit-root .table thead.table-light {
+  --bs-table-bg: var(--clr-surface-a30);
+  --bs-table-color: var(--clr-light-a0);
+  background-color: var(--clr-surface-a30);
+  color: var(--clr-light-a0);
+}
+#habit-root .table-bordered {
+  border-color: rgba(255,255,255,0.12);
+}
+#habit-root .table-bordered > :not(caption) > * {
+  border-color: rgba(255,255,255,0.12);
+}
+#habit-root .table-bordered > :not(caption) > * > * {
+  border-color: rgba(255,255,255,0.12);
+  background-color: var(--clr-surface-a20);
+}
+
+#habit-root .chart-wrap-sm {
+  background: var(--clr-surface-a20);
+  border: var(--border-soft);
+  border-radius: var(--radius-md);
+  padding: .75rem;
+}
+
+#habit-root .badge.bg-warning.text-dark { color: #111 !important; }
+
+/* ===== Habit edit view adjustments ====================================== */
+.form-control[readonly],
+.form-control:disabled,
+.form-select:disabled {
+  background-color: var(--field-bg) !important;
+  color: var(--bs-body-color) !important;
+  border: var(--field-border) !important;
+  opacity: 1;
+}
+
+input[type=number]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+/* ===== Icon picker styles =============================================== */
+[data-iconpicker-root] { color: var(--bs-body-color, #fff); }
+
+[data-iconpicker-root] .icon-preview {
+  color: var(--clr-light-a0, #fff);
+  font-size: 1.05rem;
+}
+
+[data-iconpicker-root] .icon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
+  gap: .5rem;
+  max-height: 260px;
+  overflow: auto;
+  background: var(--clr-surface-a20, #2a2a2a);
+  border: 1px solid rgba(255,255,255,0.08) !important;
+}
+
+[data-iconpicker-root] .icon-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 56px;
+  width: 56px;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: .5rem;
+  background: var(--clr-surface-a10, #1a1a1a);
+  cursor: pointer;
+  transition: transform .05s ease-in-out, box-shadow .1s ease-in-out, background .1s ease-in-out, border-color .1s ease-in-out;
+}
+
+[data-iconpicker-root] .icon-option:hover {
+  background: var(--clr-surface-a30, #3d3d3d);
+  border-color: rgba(255,255,255,.14);
+}
+
+[data-iconpicker-root] .icon-option:focus-visible {
+  outline: 2px solid var(--clr-primary-a40, #3399ff);
+  outline-offset: 1px;
+}
+
+[data-iconpicker-root] .icon-option.active {
+  outline: 2px solid var(--clr-primary-a40, #3399ff);
+  box-shadow: 0 0 0 2px rgba(51,153,255,.18) inset;
+  background: var(--clr-surface-tonal-a10, #243344);
+  border-color: rgba(51,153,255,.35);
+}
+
+[data-iconpicker-root] .icon-option i {
+  font-size: 22px;
+  color: var(--clr-light-a0, #fff);
+}
+
+


### PR DESCRIPTION
## Summary
- centralize habit detail, edit, and icon picker styles into site.css
- remove page-specific stylesheet and inline style sections

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a58922208328ac0ac9bd04959305