### PR TITLE
feat: add basic dashboard to home page

### DIFF
--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -1,7 +1,10 @@
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
-using LifeCare.Models;
 using Microsoft.AspNetCore.Authorization;
+using LifeCare.Data;
+using LifeCare.Models;
+using LifeCare.ViewModels;
 
 namespace LifeCare.Controllers;
 
@@ -9,15 +12,24 @@ namespace LifeCare.Controllers;
 public class HomeController : Controller
 {
     private readonly ILogger<HomeController> _logger;
+    private readonly LifeCareDbContext _context;
 
-    public HomeController(ILogger<HomeController> logger)
+    public HomeController(ILogger<HomeController> logger, LifeCareDbContext context)
     {
         _logger = logger;
+        _context = context;
     }
 
     public IActionResult Index()
     {
-        return View();
+        var model = new HomeDashboardVM
+        {
+            UsersCount = _context.Users.Count(),
+            HabitsCount = _context.Habits.Count(),
+            CategoriesCount = _context.Categories.Count()
+        };
+
+        return View(model);
     }
 
     public IActionResult Privacy()

--- a/ViewModels/HomeDashboardVM.cs
+++ b/ViewModels/HomeDashboardVM.cs
@@ -1,0 +1,8 @@
+namespace LifeCare.ViewModels;
+
+public class HomeDashboardVM
+{
+    public int UsersCount { get; set; }
+    public int HabitsCount { get; set; }
+    public int CategoriesCount { get; set; }
+}

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,10 +1,38 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
+@model HomeDashboardVM
+@{
+    ViewData["Title"] = "Dashboard";
 }
 
-<section class="news">
-    <h2>Latest Updates</h2>
-    <ul>
-        <li><a href="/News">View recent commits</a></li>
-    </ul>
-</section>
+<div class="container my-5">
+    <h2 class="mb-4 text-center">Dashboard</h2>
+    <div class="row text-center">
+        <div class="col-md-4 mb-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Users</h5>
+                    <p class="display-6">@Model.UsersCount</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Habits</h5>
+                    <p class="display-6">@Model.HabitsCount</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Categories</h5>
+                    <p class="display-6">@Model.CategoriesCount</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <section class="news mt-5 text-center">
+        <h3>Latest Updates</h3>
+        <a class="btn btn-outline-primary" href="/News">View recent commits</a>
+    </section>
+</div>

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
-﻿@using LifeCare
+@using LifeCare
 @using LifeCare.Models
+@using LifeCare.ViewModels
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
## Summary
- show simple dashboard on home page with counts of users, habits, and categories
- add HomeDashboardVM and inject DbContext into HomeController
- link to latest commit news from dashboard

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a8dffa248328b63f8de97aae4a6f