### PR TITLE
Add category management and navigation from habits

### DIFF
--- a/Views/Category/Edit.cshtml
+++ b/Views/Category/Edit.cshtml
@@ -1,0 +1,22 @@
+@model LifeCare.ViewModels.CategoryVM
+
+@{
+    ViewData["Title"] = "Edytuj kategorię";
+}
+
+<h2>Edytuj kategorię</h2>
+
+<form asp-action="Edit" method="post">
+    <input type="hidden" asp-for="Id" />
+    <div class="mb-3">
+        <label asp-for="Name" class="form-label"></label>
+        <input asp-for="Name" class="form-control" />
+        <span asp-validation-for="Name" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Zapisz</button>
+    <a asp-action="Index" class="btn btn-secondary">Anuluj</a>
+</form>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/Views/Category/Index.cshtml
+++ b/Views/Category/Index.cshtml
@@ -1,0 +1,31 @@
+@model IEnumerable<LifeCare.Models.Category>
+
+@{
+    ViewData["Title"] = "Kategorie";
+}
+
+<h2 class="mb-4">Kategorie</h2>
+<a asp-action="Create" class="btn btn-primary mb-3">Dodaj kategorię</a>
+<table class="table table-dark table-striped">
+    <thead>
+        <tr>
+            <th>Nazwa</th>
+            <th>Akcje</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var category in Model)
+        {
+            <tr>
+                <td>@category.Name</td>
+                <td>
+                    <a asp-action="Edit" asp-route-id="@category.Id" class="btn btn-sm btn-secondary">Edytuj</a>
+                    <form asp-action="Delete" asp-route-id="@category.Id" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Czy na pewno chcesz usunąć?');">Usuń</button>
+                    </form>
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>
+<a asp-controller="Habits" asp-action="Index" class="btn btn-secondary">Powrót do nawyków</a>

--- a/Views/Habits/Index.cshtml
+++ b/Views/Habits/Index.cshtml
@@ -9,9 +9,12 @@ var categories = ViewBag.Categories as List<LifeCare.Models.Category>;
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>Twoje nawyki</h2>
-        <a asp-action="Create" class="btn btn-primary">
-            <i class="fa fa-plus"></i>
-        </a>
+        <div>
+            <a asp-action="Create" class="btn btn-primary me-2">
+                <i class="fa fa-plus"></i>
+            </a>
+            <a asp-controller="Category" asp-action="Index" class="btn btn-secondary">Kategorie</a>
+        </div>
     </div>
 
     <!-- Kalendarz z przyciskami do zmiany tygodnia -->


### PR DESCRIPTION
## Summary
- add category index listing for current user with edit and delete actions
- redirect habit view to new category list via navigation button
- provide edit view for renaming categories

## Testing
- ⚠️ `dotnet build` *(command failed: command not found)*
- ⚠️ `apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2be8229b88328bc6d89fe8b669265