### PR TITLE
Refine category list and warn on category deletion

### DIFF
--- a/Controllers/CategoryController.cs
+++ b/Controllers/CategoryController.cs
@@ -30,6 +30,12 @@ public class CategoryController : Controller
         var userId = _userManager.GetUserId(User);
         var categories = await _context.Categories
             .Where(c => c.UserId == userId)
+            .Select(c => new CategoryIndexVM
+            {
+                Id = c.Id,
+                Name = c.Name,
+                HabitCount = c.Habits.Count
+            })
             .ToListAsync();
         return View(categories);
     }
@@ -97,6 +103,19 @@ public class CategoryController : Controller
             .FirstOrDefaultAsync(c => c.Id == id && c.UserId == userId);
         if (category != null)
         {
+            var habits = await _context.Habits
+                .Where(h => h.UserId == userId && h.CategoryId == id)
+                .ToListAsync();
+
+            if (habits.Any())
+            {
+                foreach (var habit in habits)
+                {
+                    habit.CategoryId = null;
+                }
+                TempData["Message"] = $"{habits.Count} nawyki przeniesiono do kategorii domyślnej.";
+            }
+
             _context.Categories.Remove(category);
             await _context.SaveChangesAsync();
         }

--- a/ViewModels/CategoryIndexVM.cs
+++ b/ViewModels/CategoryIndexVM.cs
@@ -1,0 +1,8 @@
+namespace LifeCare.ViewModels;
+
+public class CategoryIndexVM
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public int HabitCount { get; set; }
+}

--- a/Views/Category/Index.cshtml
+++ b/Views/Category/Index.cshtml
@@ -1,31 +1,39 @@
-@model IEnumerable<LifeCare.Models.Category>
+@model IEnumerable<LifeCare.ViewModels.CategoryIndexVM>
 
 @{
     ViewData["Title"] = "Kategorie";
 }
 
 <h2 class="mb-4">Kategorie</h2>
+@if (TempData["Message"] != null)
+{
+    <div class="alert alert-info">@TempData["Message"]</div>
+}
 <a asp-action="Create" class="btn btn-primary mb-3">Dodaj kategorię</a>
-<table class="table table-dark table-striped">
-    <thead>
-        <tr>
-            <th>Nazwa</th>
-            <th>Akcje</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var category in Model)
-        {
-            <tr>
-                <td>@category.Name</td>
-                <td>
-                    <a asp-action="Edit" asp-route-id="@category.Id" class="btn btn-sm btn-secondary">Edytuj</a>
-                    <form asp-action="Delete" asp-route-id="@category.Id" method="post" class="d-inline">
-                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Czy na pewno chcesz usunąć?');">Usuń</button>
-                    </form>
-                </td>
-            </tr>
-        }
-    </tbody>
-</table>
+
+<div class="mb-3">
+    @foreach (var category in Model)
+    {
+        <div class="d-flex align-items-center mb-1">
+            <code class="bg-dark text-light px-2 py-1 rounded flex-grow-1">@category.Name</code>
+            <a asp-action="Edit" asp-route-id="@category.Id" class="btn btn-sm btn-outline-secondary ms-2">Edytuj</a>
+            <form asp-action="Delete" asp-route-id="@category.Id" method="post" class="d-inline ms-1">
+                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirmDelete(@category.HabitCount)">Usuń</button>
+            </form>
+        </div>
+    }
+</div>
+
 <a asp-controller="Habits" asp-action="Index" class="btn btn-secondary">Powrót do nawyków</a>
+
+@section Scripts {
+    <script>
+        function confirmDelete(count) {
+            let message = 'Czy na pewno chcesz usunąć?';
+            if (count > 0) {
+                message = `Usunięcie kategorii spowoduje przeniesienie ${count} nawyków do kategorii domyślnej. Kontynuować?`;
+            }
+            return confirm(message);
+        }
+    </script>
+}


### PR DESCRIPTION
## Summary
- restyle category index to a slim code-like list
- warn users when deleting categories that contain habits
- move habits to default category on deletion

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2bfc7a3088328893413783404c92b