### PR TITLE
Show commit hash in site footer

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -21,6 +21,8 @@ builder.Services.AddControllersWithViews();
 
 builder.Services.AddScoped<IHabitService, HabitService>();
 
+builder.Services.AddSingleton<IGitInfoService, GitInfoService>();
+
 builder.Services.AddAutoMapper(typeof(Program));
 
 var app = builder.Build();

--- a/Services/GitInfoService.cs
+++ b/Services/GitInfoService.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+using LifeCare.Services.Interfaces;
+
+namespace LifeCare.Services
+{
+    public class GitInfoService : IGitInfoService
+    {
+        public string CommitHash { get; }
+
+        public GitInfoService()
+        {
+            CommitHash = RetrieveCommitHash();
+        }
+
+        private static string RetrieveCommitHash()
+        {
+            try
+            {
+                var psi = new ProcessStartInfo("git", "rev-parse --short HEAD")
+                {
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                process?.WaitForExit();
+
+                if (process?.ExitCode == 0)
+                {
+                    return (process.StandardOutput.ReadLine() ?? string.Empty).Trim();
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return "unknown";
+        }
+    }
+}

--- a/Services/Interfaces/IGitInfoService.cs
+++ b/Services/Interfaces/IGitInfoService.cs
@@ -1,0 +1,7 @@
+namespace LifeCare.Services.Interfaces
+{
+    public interface IGitInfoService
+    {
+        string CommitHash { get; }
+    }
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,4 +1,6 @@
-﻿<!DOCTYPE html>
+﻿@using LifeCare.Services.Interfaces
+@inject IGitInfoService GitInfoService
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
@@ -66,7 +68,7 @@
 <footer class="footer mt-auto">
     <div class="container-fluid d-flex flex-column flex-md-row justify-content-between align-items-center px-3">
         <div class="text-muted small">
-            &copy; 2025 LifeCare
+            Commit: @GitInfoService.CommitHash - &copy; 2025 LifeCare
         </div>
         <div class="footer-links">
             <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>


### PR DESCRIPTION
## Summary
- add GitInfo service to fetch current commit hash
- inject GitInfo into layout and render commit hash in footer

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c19cee888328b1bc0feabe2378cd