### PR TITLE
Refine dashboard layout

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -3,23 +3,23 @@
     ViewData["Title"] = "Dashboard";
 }
 
-<section class="dashboard container my-5">
+<section class="dashboard container py-4">
     <h2 class="mb-4 text-center">Dashboard</h2>
-    <div class="row text-center">
-        <div class="col-md-4 mb-3">
-            <div class="stat-card">
+    <div class="row row-cols-1 row-cols-md-3 g-4 text-center">
+        <div class="col">
+            <div class="stat-card p-3 h-100">
                 <h5>Users</h5>
                 <p class="stat-value">@Model.UsersCount</p>
             </div>
         </div>
-        <div class="col-md-4 mb-3">
-            <div class="stat-card">
+        <div class="col">
+            <div class="stat-card p-3 h-100">
                 <h5>Habits</h5>
                 <p class="stat-value">@Model.HabitsCount</p>
             </div>
         </div>
-        <div class="col-md-4 mb-3">
-            <div class="stat-card">
+        <div class="col">
+            <div class="stat-card p-3 h-100">
                 <h5>Categories</h5>
                 <p class="stat-value">@Model.CategoriesCount</p>
             </div>

--- a/Views/Home/Index.cshtml.css
+++ b/Views/Home/Index.cshtml.css
@@ -12,20 +12,19 @@
 }
 
 .dashboard .stat-card {
-  background-color: var(--clr-surface-a20);
-  border: var(--border-soft);
+  background-color: var(--clr-surface-a10);
   color: var(--clr-light-a0);
   border-radius: var(--radius-md);
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.05);
   transition: background-color .2s ease;
-  padding: 1.25rem;
 }
 
 .dashboard .stat-card:hover {
-  background-color: var(--clr-surface-a30);
+  background-color: var(--clr-surface-a20);
 }
 
 .dashboard .stat-card .stat-value {
-  font-size: 2.5rem;
+  font-size: 2rem;
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- simplify dashboard layout with responsive grid and smaller cards
- restyle stat cards with borderless, subtle shadow for a cleaner look

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c3d4fbc483288fb63ed3c85407c6